### PR TITLE
add example for delete vertex with edge

### DIFF
--- a/example/src/main/scala/com/vesoft/nebula/examples/connector/NebulaSparkWriterExample.scala
+++ b/example/src/main/scala/com/vesoft/nebula/examples/connector/NebulaSparkWriterExample.scala
@@ -205,6 +205,9 @@ object NebulaSparkWriterExample {
       .withUser("root")
       .withPasswd("nebula")
       .withWriteMode(WriteMode.DELETE)
+      // config deleteEdge true, means delete related edges when delete vertex
+      // refer https://docs.nebula-graph.com.cn/master/3.ngql-guide/12.vertex-statements/4.delete-vertex/#_1
+      .withDeleteEdge(true)
       .build()
     df.write.nebula(config, nebulaWriteVertexConfig).writeVertices()
   }


### PR DESCRIPTION
add one config for write vertex with DELETE mode.
```
.withDeleteEdge(true)
```
the default value for withDeleteEdge is false. When config it as true, the related edges will be deleted too when delete vertex.  Refer to [DELETE VERTEX](https://docs.nebula-graph.com.cn/master/3.ngql-guide/12.vertex-statements/4.delete-vertex/#_1)