### PR TITLE
GraphProvider create session only once

### DIFF
--- a/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/nebula/GraphProvider.scala
+++ b/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/nebula/GraphProvider.scala
@@ -19,7 +19,6 @@ import com.vesoft.nebula.connector.ssl.{CASSLSignParams, SSLSignType, SelfSSLSig
 import org.apache.log4j.Logger
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ListBuffer
 
 /**
   * GraphProvider for Nebula Graph Service

--- a/nebula-spark-common/src/test/scala/com/vesoft/nebula/connector/nebula/GraphProviderTest.scala
+++ b/nebula-spark-common/src/test/scala/com/vesoft/nebula/connector/nebula/GraphProviderTest.scala
@@ -18,7 +18,7 @@ class GraphProviderTest extends AnyFunSuite with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    graphProvider = new GraphProvider(addresses, 3000)
+    graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
     val graphMock = new NebulaGraphMock
     graphMock.mockIntIdGraph()
     graphMock.mockStringIdGraph()
@@ -30,8 +30,8 @@ class GraphProviderTest extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("switchSpace") {
-    assertThrows[RuntimeException](graphProvider.switchSpace("root", "nebula", "space_not_exist"))
-    assert(graphProvider.switchSpace("root", "nebula", "test_int"))
+    assertThrows[RuntimeException](graphProvider.switchSpace("space_not_exist"))
+    assert(graphProvider.switchSpace("test_int"))
   }
 
   test("submit") {

--- a/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/reader/NebulaNgqlEdgePartitionReader.scala
+++ b/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/reader/NebulaNgqlEdgePartitionReader.scala
@@ -39,6 +39,8 @@ class NebulaNgqlEdgePartitionReader extends InputPartitionReader[InternalRow] {
     this.nebulaOptions = nebulaOptions
     this.graphProvider = new GraphProvider(
       nebulaOptions.getGraphAddress,
+      nebulaOptions.user,
+      nebulaOptions.passwd,
       nebulaOptions.timeout,
       nebulaOptions.enableGraphSSL,
       nebulaOptions.sslSignType,
@@ -46,7 +48,7 @@ class NebulaNgqlEdgePartitionReader extends InputPartitionReader[InternalRow] {
       nebulaOptions.selfSignParam
     )
     // add exception when session build failed
-    graphProvider.switchSpace(nebulaOptions.user, nebulaOptions.passwd, nebulaOptions.spaceName)
+    graphProvider.switchSpace(nebulaOptions.spaceName)
     resultSet = graphProvider.submit(nebulaOptions.ngql)
     edgeIterator = query()
   }

--- a/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/writer/NebulaWriter.scala
+++ b/nebula-spark-connector/src/main/scala/com/vesoft/nebula/connector/writer/NebulaWriter.scala
@@ -31,6 +31,8 @@ class NebulaWriter(nebulaOptions: NebulaOptions) extends Serializable {
   )
   val graphProvider = new GraphProvider(
     nebulaOptions.getGraphAddress,
+    nebulaOptions.user,
+    nebulaOptions.passwd,
     nebulaOptions.timeout,
     nebulaOptions.enableGraphSSL,
     nebulaOptions.sslSignType,
@@ -40,7 +42,7 @@ class NebulaWriter(nebulaOptions: NebulaOptions) extends Serializable {
   val isVidStringType = metaProvider.getVidType(nebulaOptions.spaceName) == VidType.STRING
 
   def prepareSpace(): Unit = {
-    graphProvider.switchSpace(nebulaOptions.user, nebulaOptions.passwd, nebulaOptions.spaceName)
+    graphProvider.switchSpace(nebulaOptions.spaceName)
   }
 
   def submit(exec: String): Unit = {

--- a/nebula-spark-connector/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
+++ b/nebula-spark-connector/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
@@ -29,9 +29,9 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write vertex into test_write_string space with delete mode") {
     SparkMock.deleteVertex()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
         + "match (v:person_connector) return v limit 100000;")
@@ -45,9 +45,9 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
     SparkMock.writeEdge()
     SparkMock.deleteVertexWithEdge()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     // assert vertex is deleted
     val vertexResultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
@@ -69,9 +69,9 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write edge into test_write_string space with delete mode") {
     SparkMock.deleteEdge()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
         + "fetch prop on friend_connector \"1\"->\"2\"@10 yield edge as e;")

--- a/nebula-spark-connector/src/test/scala/com/vesoft/nebula/connector/writer/WriteInsertSuite.scala
+++ b/nebula-spark-connector/src/test/scala/com/vesoft/nebula/connector/writer/WriteInsertSuite.scala
@@ -27,9 +27,9 @@ class WriteInsertSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write vertex into test_write_string space with insert mode") {
     SparkMock.writeVertex()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider            = new GraphProvider(addresses, 3000)
+    val graphProvider            = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val createIndexResult: ResultSet = graphProvider.submit(
       "use test_write_string; "
         + "create tag index if not exists person_index on person_connector(col1(20));")
@@ -50,9 +50,9 @@ class WriteInsertSuite extends AnyFunSuite with BeforeAndAfterAll {
     SparkMock.writeEdge()
 
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider            = new GraphProvider(addresses, 3000)
+    val graphProvider            = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val createIndexResult: ResultSet = graphProvider.submit(
       "use test_write_string; "
         + "create edge index if not exists friend_index on friend_connector(col1(20));")

--- a/nebula-spark-connector_2.2/src/main/scala/com/vesoft/nebula/connector/reader/NebulaNgqlEdgeReader.scala
+++ b/nebula-spark-connector_2.2/src/main/scala/com/vesoft/nebula/connector/reader/NebulaNgqlEdgeReader.scala
@@ -40,6 +40,8 @@ class NebulaNgqlEdgeReader extends Iterator[InternalRow] {
     this.nebulaOptions = nebulaOptions
     this.graphProvider = new GraphProvider(
       nebulaOptions.getGraphAddress,
+      nebulaOptions.user,
+      nebulaOptions.passwd,
       nebulaOptions.timeout,
       nebulaOptions.enableGraphSSL,
       nebulaOptions.sslSignType,
@@ -47,7 +49,7 @@ class NebulaNgqlEdgeReader extends Iterator[InternalRow] {
       nebulaOptions.selfSignParam
     )
     // add exception when session build failed
-    graphProvider.switchSpace(nebulaOptions.user, nebulaOptions.passwd, nebulaOptions.spaceName)
+    graphProvider.switchSpace(nebulaOptions.spaceName)
     resultSet = graphProvider.submit(nebulaOptions.ngql)
     close()
     edgeIterator = query()

--- a/nebula-spark-connector_2.2/src/main/scala/com/vesoft/nebula/connector/writer/NebulaWriter.scala
+++ b/nebula-spark-connector_2.2/src/main/scala/com/vesoft/nebula/connector/writer/NebulaWriter.scala
@@ -37,6 +37,8 @@ abstract class NebulaWriter(nebulaOptions: NebulaOptions, schema: StructType) ex
   )
   val graphProvider = new GraphProvider(
     nebulaOptions.getGraphAddress,
+    nebulaOptions.user,
+    nebulaOptions.passwd,
     nebulaOptions.timeout,
     nebulaOptions.enableGraphSSL,
     nebulaOptions.sslSignType,
@@ -46,7 +48,7 @@ abstract class NebulaWriter(nebulaOptions: NebulaOptions, schema: StructType) ex
   val isVidStringType = metaProvider.getVidType(nebulaOptions.spaceName) == VidType.STRING
 
   def prepareSpace(): Unit = {
-    graphProvider.switchSpace(nebulaOptions.user, nebulaOptions.passwd, nebulaOptions.spaceName)
+    graphProvider.switchSpace(nebulaOptions.spaceName)
   }
 
   def submit(exec: String): Unit = {

--- a/nebula-spark-connector_2.2/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
+++ b/nebula-spark-connector_2.2/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
@@ -40,8 +40,8 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   test("write edge into test_write_string space with delete mode") {
     SparkMock.deleteEdge()
-    val addresses: List[Address] = List(new Address("127.0.0.1", "root", "nebula", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
     graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =

--- a/nebula-spark-connector_2.2/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
+++ b/nebula-spark-connector_2.2/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
@@ -27,9 +27,9 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write vertex into test_write_string space with delete mode") {
     SparkMock.deleteVertex()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
         + "match (v:person_connector) return v limit 100000;")
@@ -40,10 +40,10 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   test("write edge into test_write_string space with delete mode") {
     SparkMock.deleteEdge()
-    val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
+    val addresses: List[Address] = List(new Address("127.0.0.1", "root", "nebula", 9669))
     val graphProvider = new GraphProvider(addresses, 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
         + "fetch prop on friend_connector \"1\"->\"2\"@10 yield edge as e;")

--- a/nebula-spark-connector_2.2/src/test/scala/com/vesoft/nebula/connector/writer/WriteInsertSuite.scala
+++ b/nebula-spark-connector_2.2/src/test/scala/com/vesoft/nebula/connector/writer/WriteInsertSuite.scala
@@ -26,9 +26,9 @@ class WriteInsertSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write vertex into test_write_string space with insert mode") {
     SparkMock.writeVertex()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider            = new GraphProvider(addresses, 3000)
+    val graphProvider            = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val createIndexResult: ResultSet = graphProvider.submit(
       "use test_write_string; "
         + "create tag index if not exists person_index on person_connector(col1(20));")
@@ -52,9 +52,9 @@ class WriteInsertSuite extends AnyFunSuite with BeforeAndAfterAll {
     SparkMock.writeEdge()
 
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider            = new GraphProvider(addresses, 3000)
+    val graphProvider            = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val createIndexResult: ResultSet = graphProvider.submit(
       "use test_write_string; "
         + "create edge index if not exists friend_index on friend_connector(col1(20));")

--- a/nebula-spark-connector_3.0/src/main/scala/com/vesoft/nebula/connector/writer/NebulaWriter.scala
+++ b/nebula-spark-connector_3.0/src/main/scala/com/vesoft/nebula/connector/writer/NebulaWriter.scala
@@ -31,6 +31,8 @@ class NebulaWriter(nebulaOptions: NebulaOptions) extends Serializable {
   )
   val graphProvider = new GraphProvider(
     nebulaOptions.getGraphAddress,
+    nebulaOptions.user,
+    nebulaOptions.passwd,
     nebulaOptions.timeout,
     nebulaOptions.enableGraphSSL,
     nebulaOptions.sslSignType,
@@ -40,7 +42,7 @@ class NebulaWriter(nebulaOptions: NebulaOptions) extends Serializable {
   val isVidStringType = metaProvider.getVidType(nebulaOptions.spaceName) == VidType.STRING
 
   def prepareSpace(): Unit = {
-    graphProvider.switchSpace(nebulaOptions.user, nebulaOptions.passwd, nebulaOptions.spaceName)
+    graphProvider.switchSpace(nebulaOptions.spaceName)
   }
 
   def submit(exec: String): Unit = {

--- a/nebula-spark-connector_3.0/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
+++ b/nebula-spark-connector_3.0/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
@@ -44,8 +44,8 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
     SparkMock.writeVertex()
     SparkMock.writeEdge()
     SparkMock.deleteVertexWithEdge()
-    val addresses: List[Address] = List(new Address("127.0.0.1", "root", "nebula", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
     graphProvider.switchSpace("test_write_string")
     // assert vertex is deleted
@@ -68,8 +68,8 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   test("write edge into test_write_string space with delete mode") {
     SparkMock.deleteEdge()
-    val addresses: List[Address] = List(new Address("127.0.0.1", "root", "nebula", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
     graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =

--- a/nebula-spark-connector_3.0/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
+++ b/nebula-spark-connector_3.0/src/test/scala/com/vesoft/nebula/connector/writer/WriteDeleteSuite.scala
@@ -29,9 +29,9 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write vertex into test_write_string space with delete mode") {
     SparkMock.deleteVertex()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider = new GraphProvider(addresses, 3000)
+    val graphProvider = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
         + "match (v:person_connector) return v limit 100000;")
@@ -44,10 +44,10 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
     SparkMock.writeVertex()
     SparkMock.writeEdge()
     SparkMock.deleteVertexWithEdge()
-    val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
+    val addresses: List[Address] = List(new Address("127.0.0.1", "root", "nebula", 9669))
     val graphProvider = new GraphProvider(addresses, 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     // assert vertex is deleted
     val vertexResultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
@@ -68,10 +68,10 @@ class WriteDeleteSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   test("write edge into test_write_string space with delete mode") {
     SparkMock.deleteEdge()
-    val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
+    val addresses: List[Address] = List(new Address("127.0.0.1", "root", "nebula", 9669))
     val graphProvider = new GraphProvider(addresses, 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val resultSet: ResultSet =
       graphProvider.submit("use test_write_string;"
         + "fetch prop on friend_connector \"1\"->\"2\"@10 yield edge as e;")

--- a/nebula-spark-connector_3.0/src/test/scala/com/vesoft/nebula/connector/writer/WriteInsertSuite.scala
+++ b/nebula-spark-connector_3.0/src/test/scala/com/vesoft/nebula/connector/writer/WriteInsertSuite.scala
@@ -27,9 +27,9 @@ class WriteInsertSuite extends AnyFunSuite with BeforeAndAfterAll {
   test("write vertex into test_write_string space with insert mode") {
     SparkMock.writeVertex()
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider            = new GraphProvider(addresses, 3000)
+    val graphProvider            = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val createIndexResult: ResultSet = graphProvider.submit(
       "use test_write_string; "
         + "create tag index if not exists person_index on person_connector(col1(20));")
@@ -50,9 +50,9 @@ class WriteInsertSuite extends AnyFunSuite with BeforeAndAfterAll {
     SparkMock.writeEdge()
 
     val addresses: List[Address] = List(new Address("127.0.0.1", 9669))
-    val graphProvider            = new GraphProvider(addresses, 3000)
+    val graphProvider            = new GraphProvider(addresses, "root", "nebula", 3000)
 
-    graphProvider.switchSpace("root", "nebula", "test_write_string")
+    graphProvider.switchSpace("test_write_string")
     val createIndexResult: ResultSet = graphProvider.submit(
       "use test_write_string; "
         + "create edge index if not exists friend_index on friend_connector(col1(20));")


### PR DESCRIPTION
## What type of PR is this?
- [x] enhancement

## What problem(s) does this PR solve?

#### Description:

1) 
As we can see from the code, the user and password are unique for `session` parameter.
If we try to switch spaces twice with different users:

```scala
switchSpace("root", "nebula", "space")
switchSpace("root_other", "nebula_other", "space_other")
```

then in the second case the session will be taken from the first user (`"root"`).

This means that the user is unique to the class instance and can be passed to the constructor.
This is great because it allows us to lazy initialize `session` and remove checks like `session == null`

2) The address can be obtained a little easier.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

Scala programming language does not use `null` and `null` may be removed in future Scala's versions.

There are a lot of reasons why `null` is not used in Scala. 
They are discussed in the following excellent books and articles:

- Docs:
  - [Official documentation, types](https://docs.scala-lang.org/scala3/book/first-look-at-types.html#nothing-and-null)
  - [Official documentation, fp](https://docs.scala-lang.org/scala3/book/fp-functional-error-handling.html#using-option-to-replace-null)
- Books: 
  - [Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala-second-edition)
  - [Functional Programming, Simplified](https://alvinalexander.com/photos/functional-programming-simplied-free-pdf-preview/)
- Articles:
  - [I hate NULL and all its variants!](https://alexn.org/blog/2010/05/25/i-hate-null/)
  - [Making something out of nothing (or, why None is better than NaN and NULL)](https://blog.janestreet.com/making-something-out-of-nothing-or-why-none-is-better-than-nan-and-null/)
  - [Null, NullPointerException and dealing with it](https://scalac.io/blog/null-pointer-exception-npe/)
  - [Null References: The Billion Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare)
