### PR TITLE
get rid of HostAndPort dependency for guava

### DIFF
--- a/nebula-spark-common/pom.xml
+++ b/nebula-spark-common/pom.xml
@@ -44,6 +44,12 @@
             <groupId>com.vesoft</groupId>
             <artifactId>client</artifactId>
             <version>${nebula.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <artifactId>commons-codec</artifactId>

--- a/nebula-spark-common/pom.xml
+++ b/nebula-spark-common/pom.xml
@@ -44,12 +44,6 @@
             <groupId>com.vesoft</groupId>
             <artifactId>client</artifactId>
             <version>${nebula.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <artifactId>commons-codec</artifactId>

--- a/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/NebulaOptions.scala
+++ b/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/NebulaOptions.scala
@@ -6,11 +6,9 @@
 package com.vesoft.nebula.connector
 
 import java.util.Properties
-
-import com.google.common.net.HostAndPort
 import com.vesoft.nebula.connector.ssl.{CASSLSignParams, SSLSignType, SelfSSLSignParams}
+import com.vesoft.nebula.connector.utils.AddressCheckUtil
 import org.apache.commons.lang.StringUtils
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 
 import scala.collection.mutable.ListBuffer
@@ -190,9 +188,9 @@ class NebulaOptions(@transient val parameters: CaseInsensitiveMap[String]) exten
   def getMetaAddress: List[Address] = {
     val hostPorts: ListBuffer[Address] = new ListBuffer[Address]
     for (hostPort <- metaAddress.split(",")) {
-      // check host & port by getting HostAndPort
-      val addr = HostAndPort.fromString(hostPort)
-      hostPorts.append((addr.getHost, addr.getPort))
+      // check host & port
+      val addr = AddressCheckUtil.getAddressFromString(hostPort)
+      hostPorts.append((addr._1, addr._2))
     }
     hostPorts.toList
   }
@@ -202,9 +200,9 @@ class NebulaOptions(@transient val parameters: CaseInsensitiveMap[String]) exten
     graphAddress
       .split(",")
       .foreach(hostPort => {
-        // check host & port by getting HostAndPort
-        val addr = HostAndPort.fromString(hostPort)
-        hostPorts.append((addr.getHost, addr.getPort))
+        // check host & port
+        val addr = AddressCheckUtil.getAddressFromString(hostPort)
+        hostPorts.append((addr._1, addr._2))
       })
     hostPorts.toList
   }

--- a/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/utils/AddressCheckUtil.scala
+++ b/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/utils/AddressCheckUtil.scala
@@ -1,0 +1,70 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package com.vesoft.nebula.connector.utils
+
+import com.google.common.base.Strings
+
+object AddressCheckUtil {
+
+  def getAddressFromString(addr: String): (String, Int) = {
+    if (addr == null) {
+      throw new IllegalArgumentException("wrong address format.")
+    }
+    var host: String       = null
+    var portString: String = null
+
+    if (addr.startsWith("[")) {
+      val hostAndPort = getHostAndPortFromBracketedHost(addr)
+      host = hostAndPort._1
+      portString = hostAndPort._2
+    } else {
+      val colonPos = addr.indexOf(":")
+      if (colonPos >= 0 && addr.indexOf(":", colonPos + 1) == -1) {
+        host = addr.substring(0, colonPos)
+        portString = addr.substring(colonPos + 1)
+      } else {
+        host = addr
+      }
+    }
+
+    var port = -1;
+    if (!Strings.isNullOrEmpty(portString)) {
+      for (c <- portString.toCharArray) {
+        if (!Character.isDigit(c)) {
+          throw new IllegalArgumentException(s"Port must be numeric: $addr")
+        }
+      }
+      port = Integer.parseInt(portString)
+      if (port < 0 || port > 65535) {
+        throw new IllegalArgumentException(s"Port number out of range: $addr")
+      }
+    }
+    (host, port)
+  }
+
+  def getHostAndPortFromBracketedHost(addr: String): (String, String) = {
+    val colonIndex        = addr.indexOf(":")
+    val closeBracketIndex = addr.lastIndexOf("]")
+    if (colonIndex < 0 || closeBracketIndex < colonIndex) {
+      throw new IllegalArgumentException(s"invalid bracketed host/port: $addr")
+    }
+    val host: String = addr.substring(1, closeBracketIndex)
+    if (closeBracketIndex + 1 == addr.length) {
+      return (host, "")
+    } else {
+      if (addr.charAt(closeBracketIndex + 1) != ':') {
+        throw new IllegalArgumentException(s"only a colon may follow a close bracket: $addr")
+      }
+      for (i <- closeBracketIndex + 2 until addr.length) {
+        if (!Character.isDigit(addr.charAt(i))) {
+          throw new IllegalArgumentException(s"Port must be numeric: $addr")
+        }
+      }
+    }
+    (host, addr.substring(closeBracketIndex + 2))
+  }
+
+}

--- a/nebula-spark-common/src/test/scala/com/vesoft/nebula/connector/AddressCheckUtilsSuite.scala
+++ b/nebula-spark-common/src/test/scala/com/vesoft/nebula/connector/AddressCheckUtilsSuite.scala
@@ -1,0 +1,48 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package com.vesoft.nebula.connector
+
+import com.vesoft.nebula.connector.utils.AddressCheckUtil
+import org.scalatest.funsuite.AnyFunSuite
+
+class AddressCheckUtilsSuite extends AnyFunSuite {
+
+  test("checkAddress") {
+    var addr        = "127.0.0.1:9669"
+    var hostAddress = AddressCheckUtil.getAddressFromString(addr)
+    assert("127.0.0.1".equals(hostAddress._1))
+    assert(hostAddress._2 == 9669)
+
+    addr = "localhost:9669"
+    hostAddress = AddressCheckUtil.getAddressFromString(addr)
+    assert("localhost".equals(hostAddress._1))
+
+    addr = "www.baidu.com:22"
+    hostAddress = AddressCheckUtil.getAddressFromString(addr)
+    assert(hostAddress._2 == 22)
+
+    addr = "[2023::2]:65535"
+    hostAddress = AddressCheckUtil.getAddressFromString(addr)
+    assert(hostAddress._2 == 65535)
+
+    addr = "2023::3"
+    hostAddress = AddressCheckUtil.getAddressFromString(addr)
+    assert(hostAddress._1.equals("2023::3"))
+    assert(hostAddress._2 == -1)
+
+    // bad address
+    addr = "localhost:65536"
+    assertThrows[IllegalArgumentException](AddressCheckUtil.getAddressFromString(addr))
+    addr = "localhost:-1"
+    assertThrows[IllegalArgumentException](AddressCheckUtil.getAddressFromString(addr))
+    addr = "[localhost]:9669"
+    assertThrows[IllegalArgumentException](AddressCheckUtil.getAddressFromString(addr))
+    addr = "www.baidu.com:+25"
+    assertThrows[IllegalArgumentException](AddressCheckUtil.getAddressFromString(addr))
+    addr = "[]:8080"
+    assertThrows[IllegalArgumentException](AddressCheckUtil.getAddressFromString(addr))
+  }
+}


### PR DESCRIPTION
# Why this pr?
connector used guava's HostAndPort to verify  the validity of server address, but caused some conflict with the guava in the spark environment or hadoop environment. Because the interface to get the host from HostAndPort changed between guava 14 and other higher version. (getHostText() in guava 14, and getHost() in higher guava version.)

# how to do
We get rid of the HostAndPort dependency for  guava to avoid the version conflict when using getHostText() interface, and implement the verification for server address.