### PR TITLE
getHostAndPortFromBracketedHost refactor

### DIFF
--- a/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/utils/AddressCheckUtil.scala
+++ b/nebula-spark-common/src/main/scala/com/vesoft/nebula/connector/utils/AddressCheckUtil.scala
@@ -53,18 +53,17 @@ object AddressCheckUtil {
     }
     val host: String = addr.substring(1, closeBracketIndex)
     if (closeBracketIndex + 1 == addr.length) {
-      return (host, "")
+      (host, "")
+    } else if (addr.charAt(closeBracketIndex + 1) != ':') {
+      throw new IllegalArgumentException(s"only a colon may follow a close bracket: $addr")
     } else {
-      if (addr.charAt(closeBracketIndex + 1) != ':') {
-        throw new IllegalArgumentException(s"only a colon may follow a close bracket: $addr")
-      }
-      for (i <- closeBracketIndex + 2 until addr.length) {
-        if (!Character.isDigit(addr.charAt(i))) {
-          throw new IllegalArgumentException(s"Port must be numeric: $addr")
-        }
+      val port = addr.substring(closeBracketIndex + 2)
+      if (port.forall(_.isDigit)) {
+        (host, port)
+      } else {
+        throw new IllegalArgumentException(s"Port must be numeric: $addr")
       }
     }
-    (host, addr.substring(closeBracketIndex + 2))
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] enhancement

## What problem(s) does this PR solve?
#### Description:

Scala does not use the `return` keyword.

- https://stackoverflow.com/questions/12560463/return-in-scala
- https://tpolecat.github.io/2014/05/09/return.html

Maybe we can rewrite `getHostAndPortFromBracketedHost` a bit without using `return`?


